### PR TITLE
Fix "rowCut" being leaked into globals

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,31 +30,6 @@ function trimHtml(html, options) {
         tagStack = [],
         more = false;
 
-    // count symbols like one char
-    function getCharArr(string) {
-
-        var charArr = [],
-            subRow,
-            match,
-            char;
-
-        for (var i = 0; i < rowCut.length; i++) {
-
-            subRow = rowCut.substring(i);
-            match = subRow.match(/^&[a-z0-9#]+;/);
-
-            if (match) {
-                char = match[0];
-                charArr.push(char);
-                i += (char.length - 1);
-            } else {
-                charArr.push(rowCut[i]);
-            }
-        }
-
-        return charArr;
-    }
-
     for (var i = 0; i < arr.length; i++) {
 
         row = arr[i];
@@ -148,6 +123,31 @@ function trimHtml(html, options) {
         html: arr.join("\n").replace(/\n/g, ""),
         more: more
     };
+}
+
+// count symbols like one char
+function getCharArr(rowCut) {
+
+    var charArr = [],
+        subRow,
+        match,
+        char;
+
+    for (var i = 0; i < rowCut.length; i++) {
+
+        subRow = rowCut.substring(i);
+        match = subRow.match(/^&[a-z0-9#]+;/);
+
+        if (match) {
+            char = match[0];
+            charArr.push(char);
+            i += (char.length - 1);
+        } else {
+            charArr.push(rowCut[i]);
+        }
+    }
+
+    return charArr;
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/index.js
+++ b/index.js
@@ -24,11 +24,36 @@ function trimHtml(html, options) {
         .split("\n");
 
     var sum = 0,
-        row, cut, add,
+        row, cut, add, rowCut,
         tagMatch,
         tagName,
         tagStack = [],
         more = false;
+
+    // count symbols like one char
+    function getCharArr(string) {
+
+        var charArr = [],
+            subRow,
+            match,
+            char;
+
+        for (var i = 0; i < rowCut.length; i++) {
+
+            subRow = rowCut.substring(i);
+            match = subRow.match(/^&[a-z0-9#]+;/);
+
+            if (match) {
+                char = match[0];
+                charArr.push(char);
+                i += (char.length - 1);
+            } else {
+                charArr.push(rowCut[i]);
+            }
+        }
+
+        return charArr;
+    }
 
     for (var i = 0; i < arr.length; i++) {
 
@@ -123,31 +148,6 @@ function trimHtml(html, options) {
         html: arr.join("\n").replace(/\n/g, ""),
         more: more
     };
-}
-
-// count symbols like one char
-function getCharArr(string) {
-
-    var charArr = [],
-        subRow,
-        match,
-        char;
-
-    for (var i = 0; i < rowCut.length; i++) {
-
-        subRow = rowCut.substring(i);
-        match = subRow.match(/^&[a-z0-9#]+;/);
-
-        if (match) {
-            char = match[0];
-            charArr.push(char);
-            i += (char.length - 1);
-        } else {
-            charArr.push(rowCut[i]);
-        }
-    }
-
-    return charArr;
 }
 
 if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
The `rowCut` variable was never declared, so it was leaking into globals (e.g.: `window.rowCut` on browsers).